### PR TITLE
revert: "tests: avoid HTTP error during tests due to ending request early"

### DIFF
--- a/test_stream_read_xbrl.py
+++ b/test_stream_read_xbrl.py
@@ -58,6 +58,8 @@ def test_stream_read_xbrl_zip():
             assert len(row) == len(columns)
             row_dict = dict(zip(columns, row))
             assert re.match(r'(\d{8})|([A-Z]{2}\d{6})', row_dict['company_id'])
+            if count >= 1000:
+                break
 
         assert count > 1
 
@@ -71,5 +73,7 @@ def test_stream_read_xbrl_daily_all():
             assert len(row) == len(columns)
             row_dict = dict(zip(columns, row))
             assert re.match(r'(\d{8})|([A-Z]{2}\d{6})', row_dict['company_id'])
+            if count >= 1000:
+                break
 
     assert count > 1


### PR DESCRIPTION
This reverts commit 127f5a16360ec981ca6f5f36b5a3a0e8b1d57f79.

The test_stream_read_xbrl_daily_all will take far too long without the break