### PR TITLE
feat: sync parsed data to S3 as CSV files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "boto3>=1.26.84",
+    "moto[s3]>=4.1.4",
     "pytest-cov>=4.0.0",
     "pytest-httpx>=0.21.3",
     "pytest>=7.2.1",


### PR DESCRIPTION
Note that the boto3 cient is a dev dependency, not a regular dependency. This is deliberate to keep the dependencies of this library down, especially for non-core behaviour that all users wouldn't use.

While it's a bit old-school, CSVs are quite streaming-friendly and widely supported. A downside is that there is no distinction between the empty sting and a null value, but for many use-cases this is acceptable.