### PR TITLE
fix: entity_current_legal_name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
     "pytest-cov>=4.0.0",
     "pytest-httpx>=0.21.3",
     "pytest>=7.2.1",
+    "stream-zip>=0.0.57",
 ]
 
 [project.urls]

--- a/stream_read_xbrl.py
+++ b/stream_read_xbrl.py
@@ -175,9 +175,8 @@ def _xbrl_to_rows(name_xbrl_xml_str_orig):
         ),
         'entity_current_legal_name': (
             [
-                (_av('EntityCurrentLegalOrRegisteredName'), _parse_str),
-                (_tn('EntityCurrentLegalName'), _parse_str),
-                (_custom(None, lambda element, local_name, attribute_name, context_ref: element.xpath("./*[local-name()='span'][1]")), _parse_str),
+                (_av('EntityCurrentLegalOrRegisteredName', lambda element, local_name, attribute_name, context_ref: chain((element,), element.xpath("./*[local-name()='span'][1]"),)), _parse_str),
+                (_tn('EntityCurrentLegalName', lambda element, local_name, attribute_name, context_ref: chain((element,), element.xpath("./*[local-name()='span'][1]"),)), _parse_str),
             ]
         ),
         'company_dormant': (


### PR DESCRIPTION
If the name was in a <span> element, it wouldn't be found. Instead, it would actually choose the last <span> element in the document, which would be completely unrelated text - often a page number.