### PR TITLE
feat: combine text of all child elements to handle split balance sheet dates

### DIFF
--- a/stream_read_xbrl.py
+++ b/stream_read_xbrl.py
@@ -477,7 +477,7 @@ def _xbrl_to_rows(name_xbrl_xml_str_orig):
             return
 
         for element in test.search(element, local_name, attribute_value, context_ref):
-            value = _parse(element, element.text, parse)
+            value = _parse(element, ''.join(element.itertext()), parse)
             if value is not None:
                 general_attributes_with_priorities[name] = (priority, value)
                 break
@@ -495,7 +495,7 @@ def _xbrl_to_rows(name_xbrl_xml_str_orig):
             if priority >= best_priority:
                 return
 
-            value = _parse(element, element.text, parse)
+            value = _parse(element, ''.join(element.itertext()), parse)
             if value is not None:
                 periodic_attributes_with_priorities[dates][name] = (priority, value)
                 break

--- a/test_stream_read_xbrl.py
+++ b/test_stream_read_xbrl.py
@@ -20,7 +20,7 @@ from stream_read_xbrl import (
 expected_data = ({
     'administrative_expenses': None,
     'average_number_employees_during_period': Decimal('0.02'),  # Strange, but the source seems to say this
-    'balance_sheet_date': None,
+    'balance_sheet_date': date.fromisoformat('2022-12-31'),
     'called_up_share_capital': None,
     'cash_bank_in_hand': Decimal('214222'),
     'companies_house_registered_number': '09355500',
@@ -59,7 +59,7 @@ expected_data = ({
 }, {
     'administrative_expenses': None,
     'average_number_employees_during_period': Decimal('0.02'),  # Strange, but the source seems to say this
-    'balance_sheet_date': None,
+    'balance_sheet_date': date.fromisoformat('2022-12-31'),
     'called_up_share_capital': None,
     'cash_bank_in_hand': Decimal('118470'),
     'companies_house_registered_number': '09355500',
@@ -776,3 +776,28 @@ def test_date_in_format():
     with stream_read_xbrl_zip(stream_zip(member_files)) as (columns, rows):
         row = list(rows)[0]
         assert dict(zip(columns, row))['balance_sheet_date'] == date.fromisoformat('2023-02-10')
+
+
+def test_split_date():
+    html = '''
+        <html>
+            <ix:nonNumeric  
+                name="ns11:BalanceSheetDate" 
+                xmlns:ix="http://www.xbrl.org/2013/inlineXBRL">
+                10 February 202<j>0</j>
+            </ix:nonNumeric>
+        </html>
+    '''.encode()
+
+    member_files = (
+        (
+            'Prod223_3383_00001346_20220930.html',
+            datetime.now(),
+            0o600,
+            ZIP_32,
+            (html,),
+        ),
+    )
+    with stream_read_xbrl_zip(stream_zip(member_files)) as (columns, rows):
+        row = list(rows)[0]
+        assert dict(zip(columns, row))['balance_sheet_date'] == date.fromisoformat('2020-02-10')


### PR DESCRIPTION
 It was found that balance_sheet_date can contain nested elements, and the date is in those elements. Interestingly, this was one of the existing test cases. However, in the real data, examples were found where the year was split across tags, so a test is added to handle that case.