### PR TITLE
feat: parse dates with incorrect spellings of months

### DIFF
--- a/stream_read_xbrl.py
+++ b/stream_read_xbrl.py
@@ -129,7 +129,11 @@ def _xbrl_to_rows(name_xbrl_xml_str_orig):
         day_first = format in ('datedaymonthyear', 'dateslasheu', 'datedoteu')
         if format == 'datedaymonthyearen':
             text = text.replace(' ','')
-        return dateutil.parser.parse(text, dayfirst=day_first).date()
+        try:
+            return dateutil.parser.parse(text, dayfirst=day_first).date()
+        except dateutil.parser.ParserError:
+            # Try to parse mis-spellings that still have the first 3 characters right
+            return dateutil.parser.parse(re.sub(r'([a-zA-Z]+)', lambda m: m.group(0)[:3], text), dayfirst=day_first).date()
 
     def _parse_bool(element, text):
         return False if text == 'false' else True if text == 'true' else None

--- a/test_stream_read_xbrl.py
+++ b/test_stream_read_xbrl.py
@@ -909,3 +909,29 @@ def test_date_with_exclude():
     with stream_read_xbrl_zip(stream_zip(member_files)) as (columns, rows):
         row = list(rows)[0]
         assert dict(zip(columns, row))['balance_sheet_date'] == date.fromisoformat('2017-07-31')
+
+
+def test_date_with_incorrect_spelling():
+    html = '''
+        <html>
+            <ix:nonNumeric
+                format="ixt2:datedaymonthyearen"  
+                name="ns11:BalanceSheetDate" 
+                xmlns:ix="http://www.xbrl.org/2013/inlineXBRL">
+                31 Janaury 2017
+            </ix:nonNumeric>
+        </html>
+    '''.encode()
+
+    member_files = (
+        (
+            'Prod223_3383_00001346_20220930.html',
+            datetime.now(),
+            0o600,
+            ZIP_32,
+            (html,),
+        ),
+    )
+    with stream_read_xbrl_zip(stream_zip(member_files)) as (columns, rows):
+        row = list(rows)[0]
+        assert dict(zip(columns, row))['balance_sheet_date'] == date.fromisoformat('2017-01-31')


### PR DESCRIPTION
But that still have the correct first 3 characters