### PR TITLE
fix: more robust exclude tag parsing

### DIFF
--- a/stream_read_xbrl.py
+++ b/stream_read_xbrl.py
@@ -488,7 +488,7 @@ def _xbrl_to_rows(name_xbrl_xml_str_orig):
             return
 
         for element in test.search(element, local_name, attribute_value, context_ref):
-            filtered = ((e.text or '') for e in element.iter() if etree.QName(e).localname != "exclude")
+            filtered = ((e.text or '') for e in element.iter() if e.tag.rpartition('}')[2] != "exclude")
             value = _parse(element, ''.join(filtered), parse)
             if value is not None:
                 general_attributes_with_priorities[name] = (priority, value)


### PR DESCRIPTION
This addresses the error

    ValueError: Invalid tag name 'html_ix:nonNumeric'

when searching for the exclude tag.