### PR TITLE
fix: parse dates with suffixes

### DIFF
--- a/stream_read_xbrl.py
+++ b/stream_read_xbrl.py
@@ -129,6 +129,7 @@ def _xbrl_to_rows(name_xbrl_xml_str_orig):
         day_first = format in ('datedaymonthyear', 'dateslasheu', 'datedoteu')
         if format == 'datedaymonthyearen':
             text = text.replace(' ','')
+        text = re.sub(r"(\d)((st)|(nd)|(rd)|(th))", r"\1", text)
         try:
             return dateutil.parser.parse(text, dayfirst=day_first).date()
         except dateutil.parser.ParserError:

--- a/test_stream_read_xbrl.py
+++ b/test_stream_read_xbrl.py
@@ -935,3 +935,28 @@ def test_date_with_incorrect_spelling():
     with stream_read_xbrl_zip(stream_zip(member_files)) as (columns, rows):
         row = list(rows)[0]
         assert dict(zip(columns, row))['balance_sheet_date'] == date.fromisoformat('2017-01-31')
+
+def test_date_with_suffix():
+    html = '''
+        <html>
+            <ix:nonNumeric
+                format="ixt2:datedaymonthyearen"  
+                name="ns11:BalanceSheetDate" 
+                xmlns:ix="http://www.xbrl.org/2013/inlineXBRL">
+                31st March 2017
+            </ix:nonNumeric>
+        </html>
+    '''.encode()
+
+    member_files = (
+        (
+            'Prod223_3383_00001346_20220930.html',
+            datetime.now(),
+            0o600,
+            ZIP_32,
+            (html,),
+        ),
+    )
+    with stream_read_xbrl_zip(stream_zip(member_files)) as (columns, rows):
+        row = list(rows)[0]
+        assert dict(zip(columns, row))['balance_sheet_date'] == date.fromisoformat('2017-03-31')


### PR DESCRIPTION
Some dates in xbrl tags include suffixes, for example "31st March" This was then creating errors when we parsed dates that could be misspelled by checking the first 3 letters of the month. This PR should address this issue by removing the suffixes.