### PR TITLE
fix: case insensitive date suffix removal

### DIFF
--- a/stream_read_xbrl.py
+++ b/stream_read_xbrl.py
@@ -129,7 +129,7 @@ def _xbrl_to_rows(name_xbrl_xml_str_orig):
         day_first = format in ('datedaymonthyear', 'dateslasheu', 'datedoteu')
         if format == 'datedaymonthyearen':
             text = text.replace(' ','')
-        text = re.sub(r"(\d)((st)|(nd)|(rd)|(th))", r"\1", text)
+        text = re.sub(r"(?i)(\d)((st)|(nd)|(rd)|(th))", r"\1", text)
         try:
             return dateutil.parser.parse(text, dayfirst=day_first).date()
         except dateutil.parser.ParserError:

--- a/test_stream_read_xbrl.py
+++ b/test_stream_read_xbrl.py
@@ -960,3 +960,28 @@ def test_date_with_suffix():
     with stream_read_xbrl_zip(stream_zip(member_files)) as (columns, rows):
         row = list(rows)[0]
         assert dict(zip(columns, row))['balance_sheet_date'] == date.fromisoformat('2017-03-31')
+
+def test_date_with_capitalised_suffix():
+    html = '''
+        <html>
+            <ix:nonNumeric
+                format="ixt2:datedaymonthyearen"  
+                name="ns11:BalanceSheetDate" 
+                xmlns:ix="http://www.xbrl.org/2013/inlineXBRL">
+                31ST March 2017
+            </ix:nonNumeric>
+        </html>
+    '''.encode()
+
+    member_files = (
+        (
+            'Prod223_3383_00001346_20220930.html',
+            datetime.now(),
+            0o600,
+            ZIP_32,
+            (html,),
+        ),
+    )
+    with stream_read_xbrl_zip(stream_zip(member_files)) as (columns, rows):
+        row = list(rows)[0]
+        assert dict(zip(columns, row))['balance_sheet_date'] == date.fromisoformat('2017-03-31')


### PR DESCRIPTION
In order to deal with many different date formats, we strip the date suffixes e.g. "st" in 31st. However, this was previously case sensitive and so would not strip the suffix if capitalised.