### PR TITLE
feat: add error column and populate

### DIFF
--- a/stream_read_xbrl.py
+++ b/stream_read_xbrl.py
@@ -63,7 +63,8 @@ _COLUMNS = (
     'profit_loss_on_ordinary_activities_before_tax',
     'tax_on_profit_or_loss_on_ordinary_activities',
     'profit_loss_for_period',
-    'zip_url'
+    'error',
+    'zip_url',
 )
 
 logger = logging.getLogger(__name__)
@@ -513,7 +514,7 @@ def _xbrl_to_rows(name_xbrl_xml_str_orig):
             if value is not None:
                 periodic_attributes_with_priorities[dates][name] = (priority, value)
                 break
-
+                
     for element in document.xpath('//*'):
         _, _, local_name = element.tag.rpartition('}')
         _, _, attribute_value = element.get('name', '').rpartition(':')
@@ -542,8 +543,8 @@ def _xbrl_to_rows(name_xbrl_xml_str_orig):
     sorted_periods = sorted(periods, key=lambda period: (period[0], period[1]), reverse=True)
 
     return \
-        tuple((core_attributes + general_attributes + period) for period in sorted_periods) if sorted_periods else \
-        ((core_attributes + general_attributes + (None,) * (2 + len(PERIODICAL_XPATH_MAPPINGS))),)
+        tuple((core_attributes + general_attributes + period + (None,)) for period in sorted_periods) if sorted_periods else \
+        ((core_attributes + general_attributes + (None,) * (3 + len(PERIODICAL_XPATH_MAPPINGS))),)
 
 
 @contextmanager

--- a/test_stream_read_xbrl.py
+++ b/test_stream_read_xbrl.py
@@ -55,6 +55,7 @@ expected_data = ({
     'taxonomy': '',
     'total_assets_less_current_liabilities': None,
     'turnover_gross_operating_revenue': None,
+    'error': None,
     'zip_url': None,
 }, {
     'administrative_expenses': None,
@@ -94,6 +95,7 @@ expected_data = ({
     'taxonomy': '',
     'total_assets_less_current_liabilities': None,
     'turnover_gross_operating_revenue': None,
+    'error': None,
     'zip_url': None,
 }, {
     'administrative_expenses': None,
@@ -133,6 +135,7 @@ expected_data = ({
     'taxonomy': '',
     'total_assets_less_current_liabilities': Decimal(1023),
     'turnover_gross_operating_revenue': None,
+    'error': None,
     'zip_url': None,
 }, {
     'administrative_expenses': None,
@@ -172,6 +175,7 @@ expected_data = ({
     'taxonomy': '',
     'total_assets_less_current_liabilities': Decimal(100),
     'turnover_gross_operating_revenue': None,
+    'error': None,
     'zip_url': None,
 }, {
     'administrative_expenses': None,
@@ -211,6 +215,7 @@ expected_data = ({
     'taxonomy': '',
     'total_assets_less_current_liabilities': Decimal(3887),
     'turnover_gross_operating_revenue': None,
+    'error': None,
     'zip_url': None,
 }, {
     'administrative_expenses': None,
@@ -250,6 +255,7 @@ expected_data = ({
     'taxonomy': '',
     'total_assets_less_current_liabilities': Decimal(8382),
     'turnover_gross_operating_revenue': None,
+    'error': None,
     'zip_url': None,
 }, {
     'administrative_expenses': None,
@@ -289,6 +295,7 @@ expected_data = ({
     'taxonomy': '',
     'total_assets_less_current_liabilities': None,
     'turnover_gross_operating_revenue': None,
+    'error': None,
     'zip_url': None,
 }, {
     'administrative_expenses': None,
@@ -328,6 +335,7 @@ expected_data = ({
     'taxonomy': '',
     'total_assets_less_current_liabilities': None,
     'turnover_gross_operating_revenue': None,
+    'error': None,
     'zip_url': None,
 }, {
     'administrative_expenses': None,
@@ -367,6 +375,7 @@ expected_data = ({
     'taxonomy': '',
     'total_assets_less_current_liabilities': Decimal(388507),
     'turnover_gross_operating_revenue': None,
+    'error': None,
     'zip_url': None,
 }, {
     'administrative_expenses': None,
@@ -406,6 +415,7 @@ expected_data = ({
     'taxonomy': '',
     'total_assets_less_current_liabilities': None,
     'turnover_gross_operating_revenue': None,
+    'error': None,
     'zip_url': None,
 }, {
     'administrative_expenses': None,
@@ -445,6 +455,7 @@ expected_data = ({
     'taxonomy': '',
     'total_assets_less_current_liabilities': Decimal(1236),
     'turnover_gross_operating_revenue': None,
+    'error': None,
     'zip_url': None,
 }, {
     'administrative_expenses': None,
@@ -484,6 +495,7 @@ expected_data = ({
     'taxonomy': '',
     'total_assets_less_current_liabilities': None,
     'turnover_gross_operating_revenue': None,
+    'error': None,
     'zip_url': None,
 }, {
     'administrative_expenses': None,
@@ -523,6 +535,7 @@ expected_data = ({
     'taxonomy': '',
     'total_assets_less_current_liabilities': Decimal(1),
     'turnover_gross_operating_revenue': None,
+    'error': None,
     'zip_url': None,
 })
 

--- a/test_stream_read_xbrl.py
+++ b/test_stream_read_xbrl.py
@@ -998,3 +998,28 @@ def test_date_with_capitalised_suffix():
     with stream_read_xbrl_zip(stream_zip(member_files)) as (columns, rows):
         row = list(rows)[0]
         assert dict(zip(columns, row))['balance_sheet_date'] == date.fromisoformat('2017-03-31')
+
+def test_parsing_error_captured_in_error_column():
+    html = '''
+        <html>
+            <ix:nonNumeric
+                format="ixt2:datedaymonthyearen"  
+                name="ns11:BalanceSheetDate" 
+                xmlns:ix="http://www.xbrl.org/2013/inlineXBRL">
+                31 ABCDEF 2018
+            </ix:nonNumeric>
+        </html>
+    '''.encode()
+
+    member_files = (
+        (
+            'Prod223_3383_00001346_20220930.html',
+            datetime.now(),
+            0o600,
+            ZIP_32,
+            (html,),
+        ),
+    )
+    with stream_read_xbrl_zip(stream_zip(member_files)) as (columns, rows):
+        row = list(rows)[0]
+        assert dict(zip(columns, row))['error'] == "Unknown string format: 31ABC2018"


### PR DESCRIPTION
In order to deal with the variety of exceptions thrown by the Companies House Accounts pipeline, this PR adds an error column which is populated by the error if a ValueError is thrown, allowing the pipeline to continue running.