### PR TITLE
feat: remove hack for running process from a daemon, and remove support for Python 3.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,4 @@
 comment: false
 codecov:
   notify:
-    after_n_builds: 5
+    after_n_builds: 4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "Python package to parse Companies House accounts data in a streaming way"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8.0"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
The ProcessPoolExecutor from concurrent.futures doesn't need a hack from running from a daemon for Python 3.8 onwards, at least according to https://stackoverflow.com/a/61470465/1319998.

Suspect this also works better with code coverage, so a nice bonus.