### PR TITLE
fix: use passed in httpx client

### DIFF
--- a/stream_read_xbrl.py
+++ b/stream_read_xbrl.py
@@ -594,7 +594,7 @@ def stream_read_xbrl_sync(
             return (None, None)
 
     def get_content(client, url):
-        r = httpx.get(url)
+        r = client.get(url)
         r.raise_for_status()
         return r.content
 


### PR DESCRIPTION
At the moment https://download.companieshouse.gov.uk/ seems to have a certificate that isn't recongised by certain tools, e.g. httpx. So for now, suspect a custom httpx client needs to be passed into methods with a customised `verify` argument, and this client actually needs to be used.