### PR TITLE
fix: support additional decimal format

### DIFF
--- a/stream_read_xbrl.py
+++ b/stream_read_xbrl.py
@@ -96,8 +96,10 @@ def _xbrl_to_rows(name_xbrl_xml_str_orig):
     def _parse_decimal(element, text):
         sign = -1 if element.get('sign', '') == '-' else +1
         text_without_thousands_separator = \
+            text.replace('.', '').replace(',', '.') if element.get('format', '').rpartition(':')[2] == 'numdotcomma' else \
             text.replace(' ', '') if element.get('format', '').rpartition(':')[2] == 'numspacedot' else \
             text.replace(',', '')
+
         return sign * Decimal(text_without_thousands_separator) * Decimal(10) ** Decimal(element.get('scale', '0'))
 
     def _parse_decimal_with_colon_or_dash(element, text):

--- a/test_stream_read_xbrl.py
+++ b/test_stream_read_xbrl.py
@@ -817,6 +817,31 @@ def test_employee_numbers_not_negative():
         row = list(rows)[0]
         assert dict(zip(columns, row))['average_number_employees_during_period'] == 8
 
+def test_employee_numbers_numdotcomma():
+    html = '''
+        <html>
+            <ix:nonfraction
+                xmlns:ix="http://www.xbrl.org/2013/inlineXBRL"
+                name="core:AverageNumberEmployeesDuringPeriod"
+                format="ixt:numdotcomma">
+                8.00
+            </ix:nonfraction>
+        </html>
+    '''.encode()
+
+    member_files = (
+        (
+            'Prod223_3383_00001346_20220930.html',
+            datetime.now(),
+            0o600,
+            ZIP_32,
+            (html,),
+        ),
+    )
+    with stream_read_xbrl_zip(stream_zip(member_files)) as (columns, rows):
+        row = list(rows)[0]
+        assert dict(zip(columns, row))['average_number_employees_during_period'] == 800
+
 def test_date_in_format():
     html_1 = '''
         <html>


### PR DESCRIPTION
September's accounts includes at least one file in the numdotcomma format, so this has to be supported too