### PR TITLE
Add logic to sum multiple total values in _parse_decimal with appropriate unit test

### DIFF
--- a/stream_read_xbrl.py
+++ b/stream_read_xbrl.py
@@ -99,7 +99,8 @@ def _xbrl_to_rows(name_xbrl_xml_str_orig):
             text.replace('.', '').replace(',', '.') if element.get('format', '').rpartition(':')[2] == 'numdotcomma' else \
             text.replace(' ', '') if element.get('format', '').rpartition(':')[2] == 'numspacedot' else \
             text.replace(',', '')
-
+        if ' ' in text_without_thousands_separator:
+            text_without_thousands_separator = sum(map(Decimal, text_without_thousands_separator.split(" ")))
         return sign * Decimal(text_without_thousands_separator) * Decimal(10) ** Decimal(element.get('scale', '0'))
 
     def _parse_decimal_with_colon_or_dash(element, text):

--- a/test_stream_read_xbrl.py
+++ b/test_stream_read_xbrl.py
@@ -1072,3 +1072,41 @@ def test_parsing_error_captured_in_error_column():
     with stream_read_xbrl_zip(stream_zip(member_files)) as (columns, rows):
         row = list(rows)[0]
         assert dict(zip(columns, row))['error'] == "Unknown string format: 31ABC2018"
+
+def test_multi_valued_cell():
+    html = '''
+        <html>
+            <ix:resources xmlns:ix="http://www.xbrl.org/2008/inlineXBRL">
+                <xbrli:context xmlns:xbrli="http://www.xbrl.org/2003/instance" id="FY31032024A">
+                    <xbrli:entity>
+                        <xbrli:identifier scheme=" http://www.companieshouse.gov.uk/">04799971</xbrli:identifier>
+                    </xbrli:entity>
+                    <xbrli:period>
+                        <xbrli:instant>2024-03-31</xbrli:instant>
+                    </xbrli:period>
+                </xbrli:context>
+            </ix:resources>
+            <ix:nonfraction 
+                xmlns:ix="http://www.xbrl.org/2008/inlineXBRL" 
+                contextRef="FY31032024A" 
+                decimals="0" 
+                format="ixt2:numdotdecimal" 
+                name="core:CashBankOnHand" 
+                unitRef="GBP">
+                228,726 750,000	
+            </ix:nonfraction>
+        </html>
+    '''.encode()
+
+    member_files = (
+        (
+            'Prod223_3383_00001346_20220930.html',
+            datetime.now(),
+            0o600,
+            ZIP_32,
+            (html,),
+        ),
+    )
+    with stream_read_xbrl_zip(stream_zip(member_files)) as (columns, rows):
+        row = list(rows)[0]
+        assert dict(zip(columns, row))['cash_bank_in_hand'] == 978726, dict(zip(columns, row))['cash_bank_in_hand']


### PR DESCRIPTION
To fix the issue detailed: https://github.com/uktrade/stream-read-xbrl/issues/183

Some reports had multiple values for a single cell. In this instance the values are now summed in the _parse_decimal function. 

An appropriate unit test has been added to account for this.