### PR TITLE
build(deps): pin pytest to before 8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dev = [
     "moto[s3]>=5.0.0",
     "pytest-cov>=4.0.0",
     "pytest-httpx>=0.21.3",
-    "pytest>=7.2.1",
+    "pytest>=7.2.1,<8",  # Some tests fail on v8, not found quite why
     "stream-zip>=0.0.57",
 ]
 


### PR DESCRIPTION
Some tests fail on v8. Not sure why at this point, but pinning to a version before 8 fixes tests.