### PR TITLE
bump: github action dependencies

### DIFF
--- a/.github/workflows/deploy-docs-to-github-pages.yml
+++ b/.github/workflows/deploy-docs-to-github-pages.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup Pages
       uses: actions/configure-pages@v3
     - name: Install dependencies
@@ -19,7 +19,7 @@ jobs:
     - name: Build with Eleventy
       run: npx eleventy
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v2
+      uses: actions/upload-pages-artifact@v3
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-package-to-pypi.yml
+++ b/.github/workflows/deploy-package-to-pypi.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v3
         with:
@@ -22,7 +22,7 @@ jobs:
           pip install build
           python -m build
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./dist
 
@@ -36,7 +36,7 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
           - "3.12"
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
       - uses: "actions/setup-python@v4"
         with:
           python-version: '${{ matrix.python-version }}'


### PR DESCRIPTION
Bumping dependencies to fix the pypi deploy.

Specifically to fix the following build error:


```
build
Missing download info for actions/upload-artifact@v3
```
