### PR TITLE
fix: add personal data exclusions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
         pass_filenames: false
         always_run: true
   - repo: https://github.com/uktrade/github-standards
-    rev: v1.2.1 # This should be the latest github released tag, see https://github.com/uktrade/github-standards/releases for the latest tag
+    rev: v1.4.0 # This should be the latest github released tag, see https://github.com/uktrade/github-standards/releases for the latest tag
     hooks:
       - id: validate-security-scan
         verbose: true # This is helpful for debugging initial setup, it can be removed when the hooks are verified as working in your repository

--- a/personal-data-exclusions.txt
+++ b/personal-data-exclusions.txt
@@ -1,0 +1,6 @@
+CONTRIBUTING.md
+pyproject.toml
+test_stream_read_xbrl.py
+.benchmarks/main-1f3e82f.json
+.benchmarks/main-648b19a.json
+docs/contributing.md


### PR DESCRIPTION
# Description

presidio is picking up some email addresses which are either from github itself, useful for contact, or available anyway as this is a public repo and they are of a contributor, along with a fake half a postcode. exluding these from scanning

Signed-off-by: DBT pre-commit check

## Contributors

Let's acknowledge the people who contributed to the work.

## Type of change

- [ ] Refactoring (made code better without changing its behaviour)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How this has been tested

Please describe the tests that you ran to verify your changes.

If they are not automated tests please explain why and provide screenshots and/or instructions so they can reproduced.

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present
