### PR TITLE
fix: set endash to none when parsing

### DIFF
--- a/stream_read_xbrl.py
+++ b/stream_read_xbrl.py
@@ -98,7 +98,13 @@ def _xbrl_to_rows(
         text: str,
         parser: collections.abc.Callable[[Element, str], typing.Any],
     ) -> decimal.Decimal | None:
-        return parser(element, text.strip()) if text and text.strip() not in {"", "-", "—"} else None
+        null_value_markers = {
+            "",
+            "\u002d",  # Hyphen-Minus (ASCII)
+            "\u2013",  # En dash
+            "\u2014",  # Em dash
+        }
+        return parser(element, text.strip()) if text and text.strip() not in null_value_markers else None
 
     def _parse_str(_element: Element, text: str) -> str:
         return str(text).replace("\n", " ").replace('"', "")
@@ -782,9 +788,12 @@ def stream_read_xbrl_sync(
             tuple[tuple[datetime.date, datetime.date], typing.Generator[XBRLRow, None, None]], None, None
         ]:
             for zip_url, (start_date, end_date) in zip_urls_with_date_in_range_to_ingest:
-                with get_content_streamed(client, zip_url) as chunks, stream_read_xbrl_zip(chunks, zip_url=zip_url) as (
-                    _,
-                    rows,
+                with (
+                    get_content_streamed(client, zip_url) as chunks,
+                    stream_read_xbrl_zip(chunks, zip_url=zip_url) as (
+                        _,
+                        rows,
+                    ),
                 ):
                     yield (start_date, end_date), rows
 

--- a/test_stream_read_xbrl.py
+++ b/test_stream_read_xbrl.py
@@ -1322,8 +1322,15 @@ def test_multi_valued_cell() -> None:
         ]
 
 
-def test_parsing_decimal_emdash() -> None:
-    html = b"""
+dashes = [
+    "\u2013",  # En dash
+    "\u2014",  # Em dash
+]
+
+
+@pytest.mark.parametrize("dash", dashes)
+def test_parsing_decimal_dashes(dash: str) -> None:
+    html = f"""
         <html>
             <ix:resources xmlns:ix="http://www.xbrl.org/2008/inlineXBRL">
                 <xbrli:context xmlns:xbrli="http://www.xbrl.org/2003/instance" id="c-1">
@@ -1343,10 +1350,10 @@ def test_parsing_decimal_emdash() -> None:
                 decimals="0"
                 name="core:TurnoverRevenue"
                 format="ixt:zerodash">
-                &#8212;
+                {dash}
             </ix:nonFraction>
         </html>
-    """
+    """.encode()
 
     member_files = (
         (


### PR DESCRIPTION
# Description

File within zip release `Accounts_Bulk_Data-2026-06-20` contained Endash in place of decimal value. When parsed its returns an `InvalidOperation [<class 'decimal.ConversionSyntax'>]` error.  An additional Endash check is added to the `_parse` method to set value to None if present.

## Contributors
@john-poole 

## Type of change

- [ ] Refactoring (made code better without changing its behaviour)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How this has been tested

Added test case to `test_parsing_decimal_dashes`. 

Tested CompaniesHouseAccountsPipeline locally with watermark 2026-06-19:
- `stream-read-xbrl==0.0.47`- run failed.
- `stream_read_xbrl-*.whl` - local whl with changes applied, run succeeded.


## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present
