### PR TITLE
chore: Updating SRE contact email address (SR-4422)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ addopts = [
 name = "stream-read-xbrl"
 version = "0.0.0.dev0"
 authors = [
-  { name="Department for Business and Trade", email="sre@digital.trade.gov.uk" },
+  { name="Department for Business and Trade", email="sre@businessandtrade.gov.uk" },
 ]
 description = "Python package to parse Companies House accounts data in a streaming way"
 readme = "README.md"


### PR DESCRIPTION
Work as part of SRE Jira ticket: https://uktrade.atlassian.net/browse/SR-4422. PR to update any existing references to sre@digital.trade.gov.uk, due to the upcoming deprecatiion of this inbox. SRE contact email address has been updated to sre@businessandtrade.gov.uk.